### PR TITLE
fixes #20: multiple default exports in App.js

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -18,7 +18,7 @@ import Game from './Game'
 import Player from './Player'
 import Team from './Team'
 
-export default class App extends Component {
+class App extends Component {
 
   constructor (props) {
     super(props)


### PR DESCRIPTION
fixes #20: multiple default exports in App.js

As redux is used, `App.js` should export component connected to the store.
